### PR TITLE
Fix: Code was monochrome

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,11 @@ theme:
     - navigation.tracking
     - navigation.sections
     - navigation.path
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences


### PR DESCRIPTION
This enables syntax highlighting according to the mkdocs documentation:
https://squidfunk.github.io/mkdocs-material/reference/code-blocks/
