### PR TITLE
Fix the edit button in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,3 +41,4 @@ extra_css:
   - stylesheets/aleph-branding.css
 
 repo_url: https://github.com/aleph-im/aleph-docs
+edit_uri: edit/main/docs/


### PR DESCRIPTION
mkdocs was pointing to the wrong branch by default.

cf https://www.mkdocs.org/user-guide/configuration/#edit_uri