### PR TITLE
Fix misleading file upload examples

### DIFF
--- a/docs/computing/volumes/immutable.md
+++ b/docs/computing/volumes/immutable.md
@@ -27,7 +27,7 @@ mksquashfs ./custom-data data.squashfs
 ### 2. Publish the file on aleph.im
 
 ```shell
-aleph file pin ./data.squashfs
+aleph file upload ./data.squashfs
 ```
 
 This command will provide you with the `item_hash` of the immutable volume, which you can then use to create the
@@ -54,7 +54,7 @@ mksquashfs ./packages packages.squashfs
 ### 3. Publish the file on aleph.im
 
 ```shell
-aleph file pin ./packages.squashfs
+aleph file upload ./packages.squashfs
 ```
 
 This command will provide you with the `item_hash` of the immutable volume, which you can then use to create the


### PR DESCRIPTION
>Tortuga, [12/8/23 5:03 PM]
I am trying to setup a volume but I have some errors
I also tried with the CLI (never used it and it did not seem to be linked to my wallet but anyway.)
`$ aleph file pin ./data.squashfs`
ends with error:
`pydantic.error_wrappers.ValidationError: 1 validation error for StoreContent
item_hash
  Could not determine hash type: './data.squashfs' (type=value_error.unknownhash)`

>Hugo | Aleph.im, [12/8/23 5:22 PM]
Hi @tortuga0x0000 , the aleph file pin command takes an IPFS CID, not a filename. 
Have you tried the command `aleph file upload ./data.squashfs` ?

>Tortuga, [12/8/23 5:30 PM]
The doc is missleading then? It is about the "pin" command or I miss something. https://docs.aleph.im/computing/volumes/immutable/