### PR TITLE
Fix: Tabs plugins is missing which leads to incorrect display

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.arithmatex:
       generic: true
+  - pymdownx.tabbed:
+      alternate_style: true
 
 extra_javascript:
   - javascripts/mathjax.js


### PR DESCRIPTION
The page doesn't display the tabs correctly because the plugin is missing.

Solution:
Add the plugin in de yml file.