### PR TITLE
Fix: Missing redirection for Python SDK

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,3 +138,5 @@ plugins:
 
         'nodes/compute/installation/configure_caddy.md': 'nodes/compute/installation/configure-caddy.md'
 
+        'libraries/Aleph.im-Python-SDK/index.md': 'libraries/python-sdk/index.md'
+


### PR DESCRIPTION
A redirection from Aleph.im-Python-SDK was not set in the redirect keymap.

Solution: Adding this redirection in the keymap