### PR TITLE
Fix: Impossible to ensure that every block of python code works

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,6 +36,10 @@ jobs:
         run: |
           hatch run testing:typing
 
+      - name: Test Python code samples
+        run: |
+          hatch run testing:test
+
 
   build:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ Run the following command to build the static site. The result will be in the `s
 ```shell
 hatch run mkdocs build
 ```
+
+## Run test suites
+
+This project uses [mktestdocs](https://github.com/koaning/mktestdocs) to check the validity of python code samples.
+Code prefixed with `python` will be tested while code prefixed with `py` is not supposed to be a valid code (example: function signatures).
+
+```shell
+hatch run testing:test
+```
+

--- a/docs/libraries/python-sdk/accounts.md
+++ b/docs/libraries/python-sdk/accounts.md
@@ -33,7 +33,7 @@ ALEPH_CONFIG_HOME's "private-keys" directory (default: `~/.aleph.im/private-keys
 
 All chains provide a `get_fallback_account` function. Example using Ethereum:
 
-```python
+```py
 
 from aleph.sdk.chains.ethereum import get_fallback_account
 
@@ -48,7 +48,7 @@ account = get_fallback_account()
 
 === "Ethereum"
 
-    ```python
+    ```py
     from aleph.sdk.chains.ethereum import ETHAccount
 
     prv = bytes.fromhex("xxxxxx")
@@ -57,7 +57,7 @@ account = get_fallback_account()
 
 === "Solana"
 
-    ```python
+    ```py
     from aleph.sdk.chains.solana import SOLAccount
 
     prv = bytes.fromhex("xxxxxx")
@@ -66,7 +66,7 @@ account = get_fallback_account()
 
 === "NULS 1 & 2"
     
-    ```python
+    ```py
     from aleph.sdk.chains.nuls import NULSAccount
 
     prv = bytes.fromhex("xxxxxx")
@@ -75,7 +75,7 @@ account = get_fallback_account()
 
 === "Tezos"
 
-    ```python
+    ```py
     from aleph.sdk.chains.tezos import XTZAccount
 
     prv = bytes.fromhex("xxxxxx")
@@ -84,7 +84,7 @@ account = get_fallback_account()
 
 === "Cosmos / Tendermint"
 
-    ```python
+    ```py
     from aleph.sdk.chains.cosmos import CosmosAccount
 
     prv = bytes.fromhex("xxxxxx")
@@ -97,7 +97,7 @@ account = get_fallback_account()
     
     Example using Substrate (if you already used a fallback on ethereum or nuls, you might consider deleting the private key file):
     
-    ```python
+    ```py
     from aleph.sdk.chains.substrate import get_fallback_account
     
     account = get_fallback_account()
@@ -105,7 +105,7 @@ account = get_fallback_account()
     
     Another example setting the mnemonics manually:
     
-    ```python
+    ```py
     from aleph.sdk.chains.substrate import DOTAccount
     
     account = DOTAccount("payment shy team bargain chest fold bless artwork identify breeze pelican category")
@@ -116,7 +116,7 @@ account = get_fallback_account()
     
     You can also change the address_type (0 for polkadot, 2 for canary, 42 generic...).
     
-    ```python
+    ```py
     from aleph.sdk.chains.substrate import DOTAccount
     account = DOTAccount("payment shy team bargain chest fold bless artwork identify breeze pelican category")
     account.get_address()  # '5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX'

--- a/docs/libraries/python-sdk/aggregates/create.md
+++ b/docs/libraries/python-sdk/aggregates/create.md
@@ -12,7 +12,7 @@ Initialize an `AuthenticatedAlephHttpClient` with an [account](../accounts.md) t
 
 ## Usage
 
-```python
+```py
 class AuthenticatedAlephHttpClient:
     ...
     async def create_aggregate(

--- a/docs/libraries/python-sdk/aggregates/delegate.md
+++ b/docs/libraries/python-sdk/aggregates/delegate.md
@@ -7,7 +7,7 @@ This can be done by with the security key
 
 ## Create a security key
 
-```python
+```py
 from aleph.sdk.chains.ethereum import get_fallback_account
 from aleph.sdk.client import AuthenticatedAlephHttpClient
 
@@ -39,7 +39,7 @@ At this moment, `TARGET_ADDRESS` should be able to update your aggregate by usin
 
 You can verify this by fetching the security aggregate:
 
-```python
+```py
 from aleph.sdk.client import AlephHttpClient
 import asyncio
 

--- a/docs/libraries/python-sdk/aggregates/query.md
+++ b/docs/libraries/python-sdk/aggregates/query.md
@@ -5,7 +5,7 @@ It exists two methods to query an aggregate:
 - `fetch_aggregate`: Query a single key
 - `fetch_aggregates`: Query all keys.
 
-```python
+```py
 def fetch_aggregate(
     self,
     address: str,
@@ -13,7 +13,7 @@ def fetch_aggregate(
 )
 ```
 
-```python
+```py
 def fetch_aggregates(
     self,
     address: str,

--- a/docs/libraries/python-sdk/error.md
+++ b/docs/libraries/python-sdk/error.md
@@ -6,7 +6,7 @@ Using `get_message_error()` will show you the error code and some details about 
 
 ## Usage
 
-```python
+```py
 async def get_message_error(
         self,
         item_hash: str,

--- a/docs/libraries/python-sdk/forget.md
+++ b/docs/libraries/python-sdk/forget.md
@@ -7,7 +7,7 @@ of the post you want to delete. You may also forget multiple posts at a time.
 
 ## Usage
 
-```python
+```py
 async def forget(
         self,
         hashes: List[str],

--- a/docs/libraries/python-sdk/posts/create.md
+++ b/docs/libraries/python-sdk/posts/create.md
@@ -8,7 +8,7 @@ Call this same function if you want to update / amend a post. see [below](#updat
 
 ## Usage
 
-```python
+```py
 async def create_post(
         self,
         post_content,

--- a/docs/libraries/python-sdk/posts/query.md
+++ b/docs/libraries/python-sdk/posts/query.md
@@ -9,7 +9,7 @@ Since version 0.8.0, `get_posts` uses a PostFilter object to specify the filters
 
 ## Usage
 
-```python
+```py
 async def get_posts(
         self,
         page_size: int = DEFAULT_PAGE_SIZE, # Default is 200
@@ -69,7 +69,7 @@ outputs something akin to:
 
 ## Usage
 
-```python
+```py
 async def get_message(
         self,
         item_hash: str,

--- a/docs/nodes/reliability/monitoring.md
+++ b/docs/nodes/reliability/monitoring.md
@@ -50,7 +50,7 @@ Again, this list is not exhaustive, and there are many other resource monitoring
 ## Node metrics
 
 Measurements of the performance and reliability of the nodes are published in the form of 
-[POST messages](../../protocol/object-types/posts/) to the Aleph.im network.
+[POST messages](../../protocol/object-types/posts.md) to the Aleph.im network.
 
 You can find [the metrics and scoring messages on the Explorer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&page=1&sender=0x4D52380D3191274a04846c89c069E6C3F2Ed94e4).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - 'Aleph Client':
             - 'Introduction': tools/aleph-client/index.md
             - 'Usage': tools/aleph-client/usage.md
+            - 'Documentation': tools/aleph-client/documentation.md
       - 'Aleph Tooling': tools/aleph-tooling.md
       - 'Multichain Indexer':
             - 'Introduction': tools/indexer/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,15 @@ dependencies = [
     "black==24.3.0",
     "isort==5.13.2",
     "ruff==0.3.4",
+    "pytest==8.1.1",
+    "mktestdocs==0.2.1",
+    "aleph-sdk-python==0.9.1",
 ]
 
 [tool.hatch.envs.testing.scripts]
 lint = "mypy . && black --check . && isort --check . && ruff check ."
 typing = "mypy ."
+test = "pytest -vv"
 
 [tool.black]
 target-version = ["py311"]

--- a/test/python_test.py
+++ b/test/python_test.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import pytest
+from mktestdocs import check_md_file
+
+PYTHON_CODE_DIRECTORY = Path(__file__).parent / "../docs/libraries/python-sdk"
+
+
+@pytest.mark.parametrize("fpath", PYTHON_CODE_DIRECTORY.glob("**/*.md"), ids=str)
+def test_run_python_code(fpath):
+    check_md_file(fpath=fpath)


### PR DESCRIPTION
We've given users plenty of examples so they can try out different functions on their own.
The problem is that we may have written some code that doesn't work at all.

Solution: use mktestdocs to test blocks of python code I wrote a file located in /docs/test/ named python_test.py The script will go to the destination path I've specified and test every block of code that starts with **'''python**.
This also means that if I've written code in python but it's not intended to be executed, it's possible to put only **'''py**, so that the code looks nice and well-formed but is not tested by mktestdocs.

To test locally, use the command below in /docs/test: 
pytest python_test.py::test_run_python_code

TO DO: Create a github action to test before building the documentation.