### PR TITLE
Improve mktestdocs setup

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test Python code samples
         run: |
-          hatch run mkdocs testing:test
+          hatch run testing:test
 
 
   build:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -54,9 +54,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install hatch
-          pip install pytest
-          pip install mktestdocs
-          pip install aleph-sdk-python
 
       - name: Build
         run: |
@@ -64,11 +61,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -vv
-          if [ $? -ne 0 ]; then
-            echo "Certains tests ont échoué."
-            exit 1
-          fi
+          hatch run mkdocs testing:pytest
 
       - name: Upload
         run: |

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -36,6 +36,10 @@ jobs:
         run: |
           hatch run testing:typing
 
+      - name: Test Python code samples
+        run: |
+          hatch run mkdocs testing:test
+
 
   build:
     runs-on: ubuntu-22.04
@@ -58,10 +62,6 @@ jobs:
       - name: Build
         run: |
           hatch run mkdocs build
-
-      - name: Run tests
-        run: |
-          hatch run mkdocs testing:pytest
 
       - name: Upload
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,15 @@ dependencies = [
     "black==24.3.0",
     "isort==5.13.2",
     "ruff==0.3.4",
+    "pytest==8.1.1",
+    "mktestdocs==0.2.1",
+    "aleph-sdk-python==0.9.1",
 ]
 
 [tool.hatch.envs.testing.scripts]
 lint = "mypy . && black --check . && isort --check . && ruff check ."
 typing = "mypy ."
+pytest = "pytest -vv"
 
 [tool.black]
 target-version = ["py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 [tool.hatch.envs.testing.scripts]
 lint = "mypy . && black --check . && isort --check . && ruff check ."
 typing = "mypy ."
-pytest = "pytest -vv"
+test = "pytest -vv"
 
 [tool.black]
 target-version = ["py311"]


### PR DESCRIPTION
1. Run tests in the test phase, not in the build phase
2. Use hatch to install test dependencies
3. Use hatch to run `pytest`