### PR TITLE
fix: CRN installation version, typos and rewards explanations with CRN halving

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ by leveraging the Aleph.im network's decentralized storage and compute capabilit
 The Aleph.im network is composed of 2 sets of nodes:
 
 * [CCNs](nodes/core/index.md), the backbone of the P2P network. They serve as an entry point into the network through an API (similar to a blockchain node's RPC).
-* [CRNs](nodes/compute/index.md), responsible for the actual compute and storage available on Aleph.im. CRNs must be tied manually to a single CCN, and each CCN is incentivized to tie up to 5 CRNs.
+* [CRNs](nodes/compute/index.md), responsible for the actual compute and storage available on Aleph.im. CRNs must be tied manually to a single CCN, and each CCN is incentivized to tie up to 3 CRNs.
 
 ### Messages
 In Aleph.im terminology, a "_message_" is similar to a "_transaction_" for a blockchain: it is a set of data sent by an end user, propagated through the entire peer-to-peer network.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ by leveraging the Aleph.im network's decentralized storage and compute capabilit
 The Aleph.im network is composed of 2 sets of nodes:
 
 * [CCNs](nodes/core/index.md), the backbone of the P2P network. They serve as an entry point into the network through an API (similar to a blockchain node's RPC).
-* [CRNs](nodes/compute/index.md), responsible for the actual compute and storage available on Aleph.im. CRNs must be tied manually to a single CCN, and each CCN is incentivized to tie up to 3 CRNs.
+* [CRNs](nodes/compute/index.md), responsible for the actual compute and storage available on Aleph.im. CRNs must be tied manually to a single CCN, and each CCN is incentivized to tie up to 5 CRNs.
 
 ### Messages
 In Aleph.im terminology, a "_message_" is similar to a "_transaction_" for a blockchain: it is a set of data sent by an end user, propagated through the entire peer-to-peer network.

--- a/docs/nodes/compute/installation/configure-caddy.md
+++ b/docs/nodes/compute/installation/configure-caddy.md
@@ -115,6 +115,6 @@ vm.yourdomain.org:443 {
 EOL
 ```
 
-Finally, restard Caddy:
+Finally, restart Caddy:
 ```shell
 sudo systemctl restart caddy

--- a/docs/nodes/compute/installation/debian-11.md
+++ b/docs/nodes/compute/installation/debian-11.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.3.0/aleph-vm.debian-11.deb
+wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.debian-11.deb
 apt install /opt/aleph-vm.debian-11.deb
 ```
 

--- a/docs/nodes/compute/installation/debian-12.md
+++ b/docs/nodes/compute/installation/debian-12.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.3.0/aleph-vm.debian-12.deb
+wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.debian-12.deb
 apt install /opt/aleph-vm.debian-12.deb
 ```
 

--- a/docs/nodes/compute/installation/ubuntu-22.04.md
+++ b/docs/nodes/compute/installation/ubuntu-22.04.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.3.0/aleph-vm.ubuntu-22.04.deb
+sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.ubuntu-22.04.deb
 sudo apt install /opt/aleph-vm.ubuntu-22.04.deb
 ```
 

--- a/docs/nodes/reliability/rewards.md
+++ b/docs/nodes/reliability/rewards.md
@@ -14,8 +14,14 @@ The performance score of a CCN affects the rewards distributed to the operator a
 - The complete reward is distributed when the score is equal to or greater than 80%
 
 The second factor that affects the rewards of a CCN is its linking to
-[Compute Resource Nodes](../compute/index.md) (CRN).  A CCN can have up to 3 CRNs linked to it, and a the CCN
-will incur a penalty of 10% of the rewards for each spot unfilled or filled with a defaulting CRN (score of 0).
+[Compute Resource Nodes](../compute/index.md) (CRN). A CCN can have up to 5 CRNs linked to it, and the CCN will incur a penalty if it has less than 3 working CRNs linked.
+The penalty is of 10% of the rewards for each spot unfilled or filled with a defaulting CRN (score of 0), with a maximum penalty of 30%.
+
+This gives the following distribution:
+- From 3 to 5 CRNs linked = 100% of rewards
+- 2 CRNs linked = 90% of rewards
+- 1 CRN linked = 80% of rewards
+- 0 CRN linked = 70% of rewards
 
 The rewards distributed does not depend on the score of other nodes in the network. Less token from the pool
 will be distributed when nodes do not perform well enough.

--- a/docs/tools/aleph-client/index.md
+++ b/docs/tools/aleph-client/index.md
@@ -44,7 +44,7 @@ aleph --help
 │ --help                                                       Show this message and exit.                │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────╮
-│ about             Display the informations of Aleph CLI                                                 │
+│ about             Display the information of Aleph CLI                                                 │
 │ account           Manage account                                                                        │
 │ aggregate         Manage aggregate messages on aleph.im                                                 │
 │ domain            Manage custom Domain (dns) on aleph.im                                                │

--- a/docs/tools/indexer/evm-indexer.md
+++ b/docs/tools/indexer/evm-indexer.md
@@ -603,7 +603,7 @@ After setting up the ethereum indexer we can add as many other networks and acco
 
 Here are the steps to add tracking of some homeverse accounts in both testnet and mainnet
 
-### 11.1 In step 1.3 install this packages aditionally
+### 11.1 In step 1.3 install this packages additionally
 
 ```sh
 npm install @aleph-indexer/oasys-verse


### PR DESCRIPTION
This PRs solves several small issues:
- Fixes the version in CRN installation docs
- Fixes some typos
- Updates the rewards section to adjust with the recent CRN halving (this part may need changes to enhance explanations)