### PR TITLE
Fix: Community projects were absent

### DIFF
--- a/docs/community/projects/index.md
+++ b/docs/community/projects/index.md
@@ -1,0 +1,26 @@
+# Community Projects
+
+These are some of the projects that the community has been working on.
+
+If you have a project you would like to share, please [open a pull request](https://github.com/aleph-im/aleph-docs/)
+to add it to this list.
+
+## Costa's Aleph Node Tracker Bot
+
+From [@VinciCosta](https://t.me/VinciCosta):
+
+> I'm excited to launch the Aleph Node Tracker Bot, designed to enhance your experience by providing real-time updates on node status. This tool is still in its experimental phase, so you might encounter some bugs or issues. Your feedback would be invaluable in improving its functionality.
+>
+> Special thanks to my beta tester @AwAZ13 who provided fantastic feedback during the initial tests and helped shape this project!
+>
+> Main Goal:
+> 🎯 To quickly notify you about any issues with Aleph nodes, aiming to reduce downtime and maintain high network reliability.
+>
+> How to Use the Bot 🤖:
+> Please check the info and instructions on the bot for detailed guidelines on how to use this service effectively. These sections will help you understand the workings of the bot and how to interact with it.
+>
+> Let’s embrace this new tool together and strengthen the network!
+>
+> 🔗 Learn More & Start Using:  [https://t.me/AlephNodeTrackerBot](https://t.me/AlephNodeTrackerBot)
+>
+> Note: This is a community-driven initiative, and I deeply value every bit of your input to enhance this service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,8 @@ nav:
           - 'Dependency volume': guides/python/dependency_volume.md
       - Rust:
           - 'Rust microVMs': guides/rust/rust_microvm.md
+  - Community:
+      - 'Projects': community/projects/index.md
 
 plugins:
   - redirects:


### PR DESCRIPTION
This adds a page, `community/projects/index.md`, mentioning projects from the community.
