### PR TITLE
Bumped aleph-vm download links' versions from 0.4.0 to 0.4.1

### DIFF
--- a/docs/nodes/compute/installation/debian-11.md
+++ b/docs/nodes/compute/installation/debian-11.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.debian-11.deb
+wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.1/aleph-vm.debian-11.deb
 apt install /opt/aleph-vm.debian-11.deb
 ```
 

--- a/docs/nodes/compute/installation/debian-12.md
+++ b/docs/nodes/compute/installation/debian-12.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.debian-12.deb
+wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.1/aleph-vm.debian-12.deb
 apt install /opt/aleph-vm.debian-12.deb
 ```
 

--- a/docs/nodes/compute/installation/ubuntu-22.04.md
+++ b/docs/nodes/compute/installation/ubuntu-22.04.md
@@ -37,7 +37,7 @@ docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector al
 Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian package.
 The procedure is similar for updates.
 ```shell
-sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.0/aleph-vm.ubuntu-22.04.deb
+sudo wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.1/aleph-vm.ubuntu-22.04.deb
 sudo apt install /opt/aleph-vm.ubuntu-22.04.deb
 ```
 


### PR DESCRIPTION
Updated the version in the three compute installation tutorials (debian11, 12 and ubuntu22.04)