### PR TITLE
Add troubleshooting for persistent storage corruption on CRNs

### DIFF
--- a/docs/nodes/compute/troubleshooting.md
+++ b/docs/nodes/compute/troubleshooting.md
@@ -76,6 +76,7 @@ The runtime of the new diagnostic VM appears to be improperly downloaded or corr
 
 ## 3) Missing Diagnostic VM Metrics
 ### Issue Summary
+
 The `diagnostic_vm_latency` metrics data is missing for your CRN, even though virtualization is reportedly operational.
 Users can check the raw network metrics data for their node on the [Message Explorer](https://explorer.aleph.im/messages?showAdvancedFilters=1&channels=aleph-scoring&type=POST&page=1).
 For more info on the data found there, see [Metrics](../reliability/metrics.md).
@@ -126,6 +127,7 @@ Check that both work on your node, on an URL similar to
 
 ## 4) IPv6 Unreachable
 ### Issue Summary
+
 When using IPv6 on a node, the network is unreachable.
 
 #### Symptoms
@@ -140,6 +142,7 @@ When using IPv6 on a node, the network is unreachable.
 - IPv6 connectivity issues with the network.
 
 ### Troubleshooting Steps
+
 1. **Check IPv6 Configuration:**
 
     - Ensure that IPv6 is enabled on the network interface.
@@ -174,3 +177,52 @@ When using IPv6 on a node, the network is unreachable.
 4. **Test Network Connectivity:**
 
     - Use `ping6` to ping the local IPv6 gateway or known IPv6 addresses like Google's DNS `2001:4860:4860::8888` to test connectivity.
+
+## 5) Persistent Storage Corruption
+### Issue Summary
+
+During operations, if the persistent storage test reveals data corruption, the system may be unable to properly read or validate data stored in the persistent volumes, potentially resulting in errors or data loss.
+
+#### Symptoms
+
+- Errors indicating that the data in persistent volumes is not valid JSON.
+- Persistent storage read failures logged during system checks.
+
+### Probable Cause
+
+The files on the disk used by the persistent volumes might have become corrupted, possibly due to abrupt shutdowns, hardware failures, or file system issues.
+
+### Troubleshooting Steps
+
+1. **Identify Corrupted Volumes:**
+
+    - Check the logs to identify which persistent volume files are causing the errors.
+
+2. **Remove Corrupted Volumes:**
+
+    - Navigate to the directory containing the corrupted volumes:
+        ```shell
+        cd /var/lib/aleph/vm/volumes/persistent/
+        ```
+    - Remove the corrupted files. Here are the commands to remove the identified corrupted volumes:
+        ```shell
+        sudo rm /var/lib/aleph/vm/volumes/persistent/63faf8b5db1cf8d965e6a464a0cb8062af8e7df131729e48738342d956f29ace/increment-storage.ext4
+        sudo rm /var/lib/aleph/vm/volumes/persistent/67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8/increment-storage.ext4
+        ```
+
+3. **Restart Services:**
+
+    - After removing the corrupted volume files, restart the affected services to trigger the recreation of the necessary storage files:
+        ```shell
+        sudo systemctl restart aleph-vm-supervisor.service
+        ```
+
+4. **Verify System Stability:**
+
+    - Monitor the system logs for new errors.
+    - Conduct tests to ensure that the persistent storage is functioning correctly.
+
+5. **Backup Regularly:**
+
+    - Implement regular backups of important data to minimize the impact of data corruption or loss.
+

--- a/docs/nodes/compute/troubleshooting.md
+++ b/docs/nodes/compute/troubleshooting.md
@@ -181,28 +181,28 @@ When using IPv6 on a node, the network is unreachable.
 ## 5) Persistent Storage Corruption
 ### Issue Summary
 
-During operations, if the persistent storage test reveals data corruption, the system may be unable to properly read or validate data stored in the persistent volumes, potentially resulting in errors or data loss.
+A Compute Resource Node exhibits issues with the `persistent_storage` feature.
 
 #### Symptoms
 
-- Errors indicating that the data in persistent volumes is not valid JSON.
-- Persistent storage read failures logged during system checks.
+- Errors in the `persistent_storage` field from the diagnostic on the index page of a CRN or on the `/status/check/fastapi` API endpoint.
+- The endpoint `/state/increment` on the diagnostic VM returns an error 500.
+- The field `diagnostic_vm_latency` is missing from the metrics.
 
 ### Probable Cause
 
-The files on the disk used by the persistent volumes might have become corrupted, possibly due to abrupt shutdowns, hardware failures, or file system issues.
+The diagnostic VM tests the capability of the VM to persist data on the host. This is done by incrementing a counter in a JSON file, itself stored in a persistent volume.
+
+When a diagnostic  virtual machine happens to be stopped while writing data to this file, it is possible to end up with a corrupt file that, for example, only contains part of the expected JSON data and cannot be parsed.
 
 ### Troubleshooting Steps
 
 1. **Identify Corrupted Volumes:**
 
-    - Check the logs to identify which persistent volume files are causing the errors.
-
+    - Identify the identifier of the two diagnostic VMs from the variables `CHECK_FASTAPI_VM_ID` and `LEGACY_CHECK_FASTAPI_VM_ID` in the [configuration of aleph-vm](https://github.com/aleph-im/aleph-vm/blob/main/src/aleph/vm/conf.py#L292-L293). 
+2. ** Stop the service**
 2. **Remove Corrupted Volumes:**
 
-    - Navigate to the directory containing the corrupted volumes:
-        ```shell
-        cd /var/lib/aleph/vm/volumes/persistent/
         ```
     - Remove the corrupted files. Here are the commands to remove the identified corrupted volumes:
         ```shell
@@ -219,10 +219,6 @@ The files on the disk used by the persistent volumes might have become corrupted
 
 4. **Verify System Stability:**
 
-    - Monitor the system logs for new errors.
-    - Conduct tests to ensure that the persistent storage is functioning correctly.
+Check the dashboard of the index page of the CRN or open the storage test endpoint on both VMs in the form `https://$YOUR_CRN_HOSTNAME/vm/$CHECK_FASTAPI_VM_ID/state/increment`
 
-5. **Backup Regularly:**
-
-    - Implement regular backups of important data to minimize the impact of data corruption or loss.
 

--- a/docs/nodes/compute/troubleshooting.md
+++ b/docs/nodes/compute/troubleshooting.md
@@ -199,26 +199,33 @@ When a diagnostic  virtual machine happens to be stopped while writing data to t
 
 1. **Identify Corrupted Volumes:**
 
-    - Identify the identifier of the two diagnostic VMs from the variables `CHECK_FASTAPI_VM_ID` and `LEGACY_CHECK_FASTAPI_VM_ID` in the [configuration of aleph-vm](https://github.com/aleph-im/aleph-vm/blob/main/src/aleph/vm/conf.py#L292-L293). 
-2. ** Stop the service**
-2. **Remove Corrupted Volumes:**
+    - Identify the identifier of the two diagnostic VMs from the variables `CHECK_FASTAPI_VM_ID` and `LEGACY_CHECK_FASTAPI_VM_ID` in the [configuration of aleph-vm](https://github.com/aleph-im/aleph-vm/blob/main/src/aleph/vm/conf.py#L292-L293).
 
+2. **Stop the service:**
+
+    - Stop the service to avoid any further corruption:
+        ```shell
+        sudo systemctl stop aleph-vm-supervisor.service
         ```
+
+3. **Remove Corrupted Volumes:**
+
     - Remove the corrupted files. Here are the commands to remove the identified corrupted volumes:
         ```shell
         sudo rm /var/lib/aleph/vm/volumes/persistent/63faf8b5db1cf8d965e6a464a0cb8062af8e7df131729e48738342d956f29ace/increment-storage.ext4
         sudo rm /var/lib/aleph/vm/volumes/persistent/67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8/increment-storage.ext4
         ```
 
-3. **Restart Services:**
+4. **Restart Services:**
 
     - After removing the corrupted volume files, restart the affected services to trigger the recreation of the necessary storage files:
         ```shell
         sudo systemctl restart aleph-vm-supervisor.service
         ```
 
-4. **Verify System Stability:**
+5. **Verify System Stability:**
 
-Check the dashboard of the index page of the CRN or open the storage test endpoint on both VMs in the form `https://$YOUR_CRN_HOSTNAME/vm/$CHECK_FASTAPI_VM_ID/state/increment`
-
-
+    - Check the dashboard of the index page of the CRN or open the storage test endpoint on both VMs opening:
+        ```
+        https://$YOUR_CRN_HOSTNAME/vm/$CHECK_FASTAPI_VM_ID/state/increment
+        ```


### PR DESCRIPTION
Based on @hoh:

> Yes, I see the issue from the logs. The persistent storage test attempts to read data from the persistent volume on disk, and the data has apparently been corrupted and is not valid JSON.

> Hugo | Aleph.im, [5/3/24 5:23 PM]
On your end. Try removing the persistent volumes using:
```
rm /var/lib/aleph/vm/volumes/persistent/63faf8b5db1cf8d965e6a464a0cb8062af8e7df131729e48738342d956f29ace/increment-storage.ext4

rm /var/lib/aleph/vm/volumes/persistent/67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8/increment-storage.ext4
```