### PR TITLE
Fix: CRN rewards were outdated, did not include halving

### DIFF
--- a/docs/nodes/reliability/rewards.md
+++ b/docs/nodes/reliability/rewards.md
@@ -78,7 +78,7 @@ Rewards for running a compute resource node (CRN) will follow the
 [Tokenomics update](https://medium.com/aleph-im/aleph-im-tokenomics-update-nov-2022-fd1027762d99) we published in
 November. 
 
-The rewards for running a performant CRN will range from 500 to 3000 tokens per month, depending on its location and the number of other nodes hosted on the same network. Running a performant node on a crowded network should result in a similar reward as today while decentralizing the network will result in higher rewards.
+The rewards for running a performant CRN will range from 250 to 1500 tokens per month, depending on its location and the number of other nodes hosted on the same network. Running a performant node on a crowded network should result in a similar reward as today while decentralizing the network will result in higher rewards.
 
 The reward of a CRN is the sum of a fixed amount and a decentralization bonus, multiplied by the score according to the
 20%-80% rule stated above.
@@ -88,7 +88,7 @@ decentralization\_score = (1 - \frac{nodes\_with\_identical\_asn}{total\_nodes})
 $$
 
 $$
-max\_rewards = 500 + decentralization\_score * 2500
+max\_rewards = 250 + decentralization\_score * 1250
 $$
 
 $$


### PR DESCRIPTION
The CRN rewards did not include the latest update about the "halving" of the rewards.

Medium blog about the update:
https://medium.com/aleph-im/crn-halving-and-what-you-need-to-know-a5511e627981

Nodestatus commit applying the change:
https://github.com/aleph-im/aleph-nodestatus/commit/94ec6d2de0ab5fe9648624de2272e851e7cc3b8b