### PR TITLE
fix: List not displayed correctly in aggregate docs

### DIFF
--- a/docs/protocol/object-types/aggregates.md
+++ b/docs/protocol/object-types/aggregates.md
@@ -19,9 +19,9 @@ The contents of the two messages are merged. Keys already present in the origina
 keys will be added.
 
 Example:
-* Original aggregate content: `{"a": 1, "b": 2}`
-* Update: `{"b": 3, "c": 4}`
-* Result: `{"a": 1, "b": 3, "c": 4}`
+- Original aggregate content: `{"a": 1, "b": 2}`
+- Update: `{"b": 3, "c": 4}`
+- Result: `{"a": 1, "b": 3, "c": 4}`
 
 ## Retrieve aggregates
 


### PR DESCRIPTION
List was using `*` instead of `-` in https://docs.aleph.im/protocol/object-types/aggregates/

<img width="686" alt="image" src="https://github.com/user-attachments/assets/2bd38a67-6b01-42d3-87a3-2881e12905c2">
