### PR TITLE
Fixes: Message signature on Base, broken anchors

### DIFF
--- a/docs/libraries/typescript-sdk/aggregates.md
+++ b/docs/libraries/typescript-sdk/aggregates.md
@@ -61,4 +61,4 @@ outputs:
 ## Delegate write access to another account
 
 If you want to delegate write access to a specific key in your aggregates, you can
-use the security aggregate like explained in the [Python SDK's section on write access delegation](../python-sdk/aggregates/delegate.md#delegate-write-access-to-an-aggregate-key).
+use the security aggregate like explained in the [Python SDK's section on write access delegation](../python-sdk/aggregates/delegate.md).

--- a/docs/nodes/compute/advanced/enable-confidential.md
+++ b/docs/nodes/compute/advanced/enable-confidential.md
@@ -1,6 +1,6 @@
 # Confidential computing
 
-This guide outlines how to enable [Confidential Computing](/computing/confidential/index.md) on a CRN.
+This guide outlines how to enable [Confidential Computing](../../../computing/confidential/index.md) on a CRN.
 
 ## Hardware requirement
 To enable Confidential Computing, your system must be equipped with 4th Generation AMD EPYC™ Processors that support Secure Encrypted Virtualization (SEV).

--- a/docs/nodes/compute/troubleshooting.md
+++ b/docs/nodes/compute/troubleshooting.md
@@ -117,7 +117,7 @@ Check that both work on your node, on an URL similar to
 
 3. **Clear Cache:**
 
-    - See [SQUASHFS Errors in running diagnostic VM](#squashfs-errors-in-running-diagnostic-vm).
+    - See [SQUASHFS Errors in running diagnostic VM](#2-squashfs-errors-in-diagnostic-vm).
 
 4. **Contact Cloud Provider:**
 

--- a/docs/protocol/chains.md
+++ b/docs/protocol/chains.md
@@ -40,5 +40,5 @@ functionalities are supported.
 | Nuls2     | Python only       |                           |                    |                 |                 |      |
 | Substrate | ✅                 |                           |                    |                 |                 |      |
 | Avalanche | ✅                 | Metamask & Wallet Connect | ✅                  |                 |                 | ✅    |
-| BASE      | Python only       | Metamask & Wallet Connect | ✅                  |                 |                 | ✅    |
+| BASE      | ✅                 | Metamask & Wallet Connect | ✅                  |                 |                 | ✅    |
 | BNB       | ✅                 | Metamask & Wallet Connect | ✅                  |                 |                 |      |


### PR DESCRIPTION
- Fix broken anchors on 3 pages
- `message signature` on `supported chains` page: Python Only -> ✅ 