### PR TITLE
Improve sevctl docs: Additional deps + Windows guidance

### DIFF
--- a/docs/computing/confidential/requirements.md
+++ b/docs/computing/confidential/requirements.md
@@ -30,13 +30,7 @@ Installing [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/inst
 curl https://sh.rustup.rs -sSf | sh
 ```
 
-Or on Ubuntu 24.04:
-
-```shell
-apt install cargo
-```
-
-On some distributions (ex: Ubuntu), sevctl requires additional dependencies:
+Some packages may need to be installed on some systems (ex: Ubuntu) in order to build sevctl:
 
 ```shell
 apt install -y pkg-config libssl-dev asciidoctor

--- a/docs/computing/confidential/requirements.md
+++ b/docs/computing/confidential/requirements.md
@@ -2,20 +2,20 @@
 
 ## System
 
-Creating a confidential virtual machine currently requires the creation of an encrypted disk on a machine you trust. 
+Creating a confidential virtual machine currently requires the creation of an encrypted disk on a machine you trust.
 This machine must run Linux on x86_64 (64 bit CPU, most recent PCs but not Mac) and have IPv6 connectivity.
 
-The documentation below assumes a Linux system based on [Debian](https://www.debian.org/) or [Ubuntu](https://ubuntu.com/), but the procedure can be adjusted to other distributions. 
+The documentation below assumes a Linux system based on [Debian](https://www.debian.org/) or [Ubuntu](https://ubuntu.com/), but the procedure can be adjusted to other distributions.
 
 This requirement will be lifted in the future with confidential virtual machines that encrypt the filesystem themself.
 
 ## Software required
 
- * The [aleph-client](https://github.com/aleph-im/aleph-client/) command-line tool
- * The [sevctl](https://github.com/virtee/sevctl) tool from AMD
- * A [OpenSSH](https://www.openssh.com/) keypair
- * An [IPFS Server](https://github.com/ipfs/kubo)
- * Optional: [Qemu](https://www.qemu.org/) to test your VM locally
+- The [aleph-client](https://github.com/aleph-im/aleph-client/) command-line tool
+- The [sevctl](https://github.com/virtee/sevctl) tool from AMD
+- A [OpenSSH](https://www.openssh.com/) keypair
+- An [IPFS Server](https://github.com/ipfs/kubo)
+- Optional: [Qemu](https://www.qemu.org/) to test your VM locally
 
 ### aleph-client
 
@@ -25,21 +25,31 @@ following [the documentation here](../../tools/aleph-client/index.md).
 ### sevctl
 
 Installing [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
+
 ```shell
 curl https://sh.rustup.rs -sSf | sh
 ```
 
-or on Ubuntu 24.04:
+Or on Ubuntu 24.04:
 
-```
+```shell
 apt install cargo
 ```
 
+On some distributions (ex: Ubuntu), sevctl requires additional dependencies:
+
+```shell
+apt install -y pkg-config libssl-dev asciidoctor
+```
+
 The [sevctl](https://github.com/virtee/sevctl) tool can then be installed using `cargo`:
+
 ```shell
 cargo install sevctl
 set --export PATH ~.cargo/bin:$PATH
 ```
+
+> ℹ️ On Windows, we recommend using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) following the same previous steps.
 
 ### guestmount
 


### PR DESCRIPTION
I tried again to install sevctl on Windows but some rust libs keep raising errors and the build step fails.
The tool seems to be incompatible with this platform, or it requires more dependencies I'm not aware of (??).
Didn't find any info online about someone that succeeded to build it on Windows, so we can recommend using WSL instead (stable and works without any issue).
Some additional deps were missing for Ubuntu ([cf](https://github.com/virtee/sevctl#ubuntu)) as well to build sevctl.