### PR TITLE
Update CRN distrib pages, auto-fetch latest versions, minor fix

### DIFF
--- a/docs/nodes/compute/installation/debian-11.md
+++ b/docs/nodes/compute/installation/debian-11.md
@@ -1,0 +1,3 @@
+# Debian 11 Bullseye (Deprecated)
+
+Since Debian 11 is not supported anymore, we recommend upgrading to the latest Debian version and then use the [following instructions on Debian 12](./debian-12.md).

--- a/docs/nodes/compute/installation/debian-11.md
+++ b/docs/nodes/compute/installation/debian-11.md
@@ -1,3 +1,3 @@
 # Debian 11 Bullseye (Deprecated)
 
-Since Debian 11 is not supported anymore, we recommend upgrading to the latest Debian version and then use the [following instructions on Debian 12](./debian-12.md).
+Support for Debian 11 has been removed since aleph-vm 1.2. It is recommended to upgrade to the latest Debian version and then use the [following instructions on Debian 12](./debian-12.md).

--- a/docs/nodes/compute/installation/ubuntu-20.04.md
+++ b/docs/nodes/compute/installation/ubuntu-20.04.md
@@ -1,10 +1,9 @@
-# Ubuntu 20.04 Focal Fossa (Deprecated) 
+# Ubuntu 20.04 Focal Fossa (Deprecated)
 
 Support for Ubuntu 20.04 was due to compatibility issues with
-the NFTables firewall introduced in version 
+the NFTables firewall introduced in version
 [0.2.6](https://github.com/aleph-im/aleph-vm/releases/tag/0.2.6).
 
-We recommend upgrading to the newest Ubuntu LTS version 
-and then use the 
-[following instructions on Ubuntu 22.04](./ubuntu-22.04.md)
-).
+We recommend upgrading to the latest Ubuntu version
+and then use the
+[following instructions on Ubuntu 24.04](./ubuntu-24.04.md).

--- a/docs/nodes/compute/installation/ubuntu-24.04.md
+++ b/docs/nodes/compute/installation/ubuntu-24.04.md
@@ -1,8 +1,8 @@
-# Debian 12 Bookworm
+# Ubuntu 24.04 Noble Numbat
 
 ## 0. Introduction
 
-For production using official Debian 12 packages.
+For production using official Ubuntu 24.04 packages.
 
 ## 1. Requirements
 
@@ -24,34 +24,34 @@ You will need a public domain name with access to add TXT and wildcard records.
 
 ## 2. Installation
 
-Run the following commands as `root`:
+Run the following commands:
 
 First install the [VM-Connector](https://github.com/aleph-im/aleph-vm/tree/main/vm_connector) using Docker:
 
 ```shell
-apt update
-apt upgrade
-apt install -y docker.io apparmor-profiles
+sudo apt update
+sudo apt upgrade
+sudo apt install -y docker.io
 docker run -d -p 127.0.0.1:4021:4021/tcp --restart=always --name vm-connector alephim/vm-connector:alpha
 ```
 
-Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Debian 12 package.
+Then install the [VM-Supervisor](https://github.com/aleph-im/aleph-vm/tree/main/src/aleph/vm/orchestrator) using the official Ubuntu 24.04 package.
 The procedure is similar for updates.
 
 ```shell
 # Download the latest release
-curl -s https://api.github.com/repos/aleph-im/aleph-vm/releases/latest | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \" | sed '1p;d' | xargs wget -P /opt -
+curl -s https://api.github.com/repos/aleph-im/aleph-vm/releases/latest | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \" | sed '3p;d' | xargs sudo wget -P /opt -
 # Install it
-apt install /opt/aleph-vm.debian-12.deb
+sudo apt install /opt/aleph-vm.ubuntu-24.04.deb
 ```
 
 Reboot if required (new kernel, ...).
 
 ### Configuration
 
-Update the configuration in `/etc/aleph-vm/supervisor.env` using your favourite editor.
-
 #### Hostname
+
+Update the configuration in `/etc/aleph-vm/supervisor.env` using your favourite editor.
 
 You will want to insert your domain name in the form of:
 
@@ -98,7 +98,7 @@ That partition must meet the minimum requirements specified for a CRN.
 Finally, restart the service:
 
 ```shell
-systemctl restart aleph-vm-supervisor
+sudo systemctl restart aleph-vm-supervisor
 ```
 
 ## 3. Reverse Proxy
@@ -115,17 +115,17 @@ This is a simple configuration. For more options, check [CONFIGURE_CADDY](config
 Again, run these commands as `root`:
 
 ```shell
- apt install -y debian-keyring debian-archive-keyring apt-transport-https
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
-apt update
-apt install caddy
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install caddy
 ```
 
 Then, after replacing the domain `vm.example.org` with your own, use configure Caddy:
 
 ```shell
-cat >/etc/caddy/Caddyfile <<EOL
+sudo cat >/etc/caddy/Caddyfile <<EOL
 {
     https_port 443
     on_demand_tls {
@@ -145,7 +145,7 @@ EOL
 Finally, restart Caddy to use the new configuration:
 
 ```shell
-systemctl restart caddy
+sudo systemctl restart caddy
 ```
 
 ## 4. Test
@@ -159,19 +159,19 @@ If you face an issue, check the logs of the different services for errors:
 VM-Supervisor:
 
 ```shell
-journalctl -f -u aleph-vm-supervisor.service
+sudo journalctl -f -u aleph-vm-supervisor.service
 ```
 
 Caddy:
 
 ```shell
-journalctl -f -u caddy.service
+sudo journalctl -f -u caddy.service
 ```
 
 VM-Connector:
 
 ```shell
-docker logs -f vm-connector
+sudo docker logs -f vm-connector
 ```
 
 ### Common errors

--- a/docs/nodes/reliability/metrics.md
+++ b/docs/nodes/reliability/metrics.md
@@ -16,9 +16,9 @@ Every hour, the measurement program creates a random plan of when to connect to 
 
 The program connects to each node using a few different methods and measures the time taken to obtain a response for each measurement (latency).
 
- - HTTP or HTTPS
- - IPv4 and IPv6
- - Ping (ICMP) requests
+- HTTP or HTTPS
+- IPv4 and IPv6
+- Ping (ICMP) requests
 
 All durations are expressed in seconds (floating numbers).
 
@@ -41,34 +41,35 @@ Some metrics are common to all node types:
 
 1. **Base latency** (`base_latency`): The time to respond to a simple request, measured by calling `/api/v0/info/public.json` (no processing on that page).
 2. **Metrics latency** (`metrics_latency`): The time to fetch public node metrics, measured by calling `/metrics.json`
-[//]: # (3. The following variables from the metrics.json response:)
-[//]: # (    a. `pyaleph_status_sync_pending_txs_total`)
-[//]: # (    b. `pyaleph_status_sync_pending_messages_total`)
-[//]: # (    c. `pyaleph_status_chain_eth_height_remaining_total`)
+   [//]: # (3. The following variables from the metrics.json response:)
+   [//]: # ( a. `pyaleph_status_sync_pending_txs_total`)
+   [//]: # ( b. `pyaleph_status_sync_pending_messages_total`)
+   [//]: # ( c. `pyaleph_status_chain_eth_height_remaining_total`)
 3. **Aggregate latency** (`aggregate_latency`): The time to fetch a large aggregate, measured by calling `/api/v0/aggregates/0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10.json?keys=corechannel&limit=50`. Accesses the database.
 4. **File download latency** (`file_download_latency`): The time to fetch a 6.7 kB file, measured by calling `/api/v0/storage/raw/50645d4ccfddb7540e7bb17ffa5609ec8a980e588e233f0e2c4451f6f9da6ebd`. Accesses the storage
 5. **Pending messages** (`pending_messages`): The number of messages in queue to be processed. Should be low except on new nodes still syncing.
 6. **Pending transactions** (`txs_total`): The number of archives to be fetched from IPFS and processed. Should be very low except on new nodes still syncing.
 7. **Ethereum height remaining** (`eth_height_remaining`): Number of [blocks](https://ethereum.org/en/developers/docs/blocks/) available on Ethereum that are newer than the newest archive processed.
- 
+
 Metrics are only valid if the HTTP response code is a success.
 
 The metrics for a CCN have the following form:
+
 ```json
 {
-    "measured_at":1680715202.614388,
-    "node_id":"5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
-    "url":"http://12.13.14.15:4024/",
-    "asn":12345,
-    "as_name":"INTERNET-SERVICE-PROVIDER, AD",
-    "version":"v0.5.0",
-    "base_latency":0.0545351505279541,
-    "metrics_latency":0.05013394355773926,
-    "aggregate_latency":0.03859257698059082,
-    "file_download_latency":0.04321122169494629,
-    "txs_total":0,
-    "pending_messages":3430570,
-    "eth_height_remaining":114822
+  "measured_at": 1680715202.614388,
+  "node_id": "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+  "url": "http://12.13.14.15:4024/",
+  "asn": 12345,
+  "as_name": "INTERNET-SERVICE-PROVIDER, AD",
+  "version": "v0.5.0",
+  "base_latency": 0.0545351505279541,
+  "metrics_latency": 0.05013394355773926,
+  "aggregate_latency": 0.03859257698059082,
+  "file_download_latency": 0.04321122169494629,
+  "txs_total": 0,
+  "pending_messages": 3430570,
+  "eth_height_remaining": 114822
 }
 ```
 
@@ -79,10 +80,11 @@ All measurements for Compute Resource Nodes are done in [IPv6](https://en.wikipe
 1. **Base latency** (`base_latency`): The time to respond to a simple request, measured by calling `/about/login` (no processing on that endpoint). Should return HTTP code `401 Unauthorized`.
 2. **Diagnostic VM latency** (`diagnostic_vm_latency`): The time to call a common user program and get a response, measured by calling `/vm/67705389842a0a1b95eaa408b009741027964edc805997475e95c505d642edd8`
 3. **Full check latency** (`full_check_latency`): The time to run a collection of checks on the node and get a response, measured by calling `/status/check/fastapi`.
-4. **Diagnostic VM Ping latency** (`diagnostic_vm_ping_latency`): The time returned by an [ICMP Ping](https://en.wikipedia.org/wiki/Ping_(networking_utility)) to the diagnostic virtual machine running on the node. This metric is only present if the VM is available via IPv6 (VM Egress IPv6). 
+4. **Diagnostic VM Ping latency** (`diagnostic_vm_ping_latency`): The time returned by an [ICMP Ping](<https://en.wikipedia.org/wiki/Ping_(networking_utility)>) to the diagnostic virtual machine running on the node. This metric is only present if the VM is available via IPv6 (VM Egress IPv6).
 5. **Base latency Ipv4** (`base_latency_ipv4`): The time same as `base_latency` above but using IPv4 instead of IPv6.
 
 The metrics for a CRN have the following form:
+
 ```json
 {
     "measured_at":1680715253.669524,
@@ -109,7 +111,8 @@ Metrics messages can be found:
 
 ### Using the Python SDK
 
-The [Python SDK](../../../libraries/python-sdk/posts/query/) provides helpers to fetch the relevant messages.
+The [Python SDK](../../libraries/python-sdk/posts/query.md) provides helpers to fetch the relevant messages.
+
 ```python
 import asyncio
 from datetime import UTC, datetime, timedelta

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,9 +71,11 @@ nav:
       - 'Introduction': nodes/compute/index.md
       - 'Installations':
         - 'Configure Caddy': nodes/compute/installation/configure-caddy.md
+        - 'Debian 11': nodes/compute/installation/debian-11.md
         - 'Debian 12': nodes/compute/installation/debian-12.md
         - 'Ubuntu 20.04': nodes/compute/installation/ubuntu-20.04.md
         - 'Ubuntu 22.04': nodes/compute/installation/ubuntu-22.04.md
+        - 'Ubuntu 24.04': nodes/compute/installation/ubuntu-24.04.md
         - 'Troubleshooting': nodes/compute/troubleshooting.md
         - 'Confidential computing': nodes/compute/advanced/enable-confidential.md
       - 'Releases': nodes/compute/releases.md


### PR DESCRIPTION
# Changes
- Add `deprecation page for Debian 11`
- Add `missing page for Ubuntu 24.04 Noble Numbat`
- Minor fix: broken link on metrics page
- During installation, `Auto-fetch latest CRN version` from github, so we don't have to update pages after each new release anymore:

```bash
# Before
wget -P /opt https://github.com/aleph-im/aleph-vm/releases/download/0.4.1/aleph-vm.debian-12.deb
# Now
curl -s https://api.github.com/repos/aleph-im/aleph-vm/releases/latest | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \" | sed '1p;d' | xargs wget -P /opt -
```