### PR TITLE
Removing the no longer supported on_demand_tls properties 'burst' and 'interval'

### DIFF
--- a/docs/nodes/compute/installation/configure-caddy.md
+++ b/docs/nodes/compute/installation/configure-caddy.md
@@ -80,14 +80,6 @@ configuration. Be careful about rate limits if you enable `on_demand` TLS,
 see the [Caddy documentation on On-Demand TLS](https://caddyserver.com/docs/automatic-https#on-demand-tls).
 ```shell
 cat >/etc/caddy/Caddyfile <<EOL
-{
-    on_demand_tls {
-        interval 60s
-        burst    5
-    }
-}
-
-
 vm.yourdomain.org:443 {
     tls /etc/letsencrypt/live/vm.yourdomain.org/fullchain.pem /etc/letsencrypt/live/vm.yourdomain.org/privkey.pem
     reverse_proxy http://127.0.0.1:4020 {

--- a/docs/nodes/compute/installation/debian-12.md
+++ b/docs/nodes/compute/installation/debian-12.md
@@ -128,10 +128,6 @@ Then, after replacing the domain `vm.example.org` with your own, use configure C
 cat >/etc/caddy/Caddyfile <<EOL
 {
     https_port 443
-    on_demand_tls {
-        interval 60s
-        burst    5
-    }
 }
 vm.example.org:443 {
     reverse_proxy http://127.0.0.1:4020 {

--- a/docs/nodes/compute/installation/ubuntu-22.04.md
+++ b/docs/nodes/compute/installation/ubuntu-22.04.md
@@ -128,10 +128,6 @@ Then, after replacing the domain `vm.example.org` with your own, use configure C
 sudo cat >/etc/caddy/Caddyfile <<EOL
 {
     https_port 443
-    on_demand_tls {
-        interval 60s
-        burst    5
-    }
 }
 vm.example.org:443 {
     reverse_proxy http://127.0.0.1:4020 {

--- a/docs/nodes/compute/installation/ubuntu-24.04.md
+++ b/docs/nodes/compute/installation/ubuntu-24.04.md
@@ -128,10 +128,6 @@ Then, after replacing the domain `vm.example.org` with your own, use configure C
 sudo cat >/etc/caddy/Caddyfile <<EOL
 {
     https_port 443
-    on_demand_tls {
-        interval 60s
-        burst    5
-    }
 }
 vm.example.org:443 {
     reverse_proxy http://127.0.0.1:4020 {


### PR DESCRIPTION
I couldn't find the caddy changelog that says why or what to do or to replace theses properties with but keeping theses blocks the caddy server from starting on the latest version (2.9.1): 

```
Jan 11 13:32:17 nf667ed caddy[2180672]: Error: adapting config using caddyfile: parsing caddyfile tokens for 'on_demand_tls': the on_demand_tls 'interval' option is no longer supported, remove it from your config, at /etc/caddy/Caddyfile:4
```

```
Jan 11 13:19:28 nf667ed caddy[2180576]: Error: adapting config using caddyfile: parsing caddyfile tokens for 'on_demand_tls': the on_demand_tls 'burst' option is no longer supported, remove it from your config, at /etc/caddy/Caddyfile:4
```