### PR TITLE
Upgrade deprecated actions/upload-artifact: v3 -> v4

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -106,7 +106,7 @@ jobs:
           ITEM_HASH=$(aleph file pin ${{ env.ipfs_cid }} | jq -r '.item_hash')
           echo 'y' | aleph domain attach docs.aleph.im --item-hash $ITEM_HASH
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: aleph-docs
           path: site


### PR DESCRIPTION
Auto-deployment is broken right now, this PR fixes the issue by upgrading actions/upload-artifact

![image](https://github.com/user-attachments/assets/4d51b73e-7197-4792-ba14-58fb78e9510e)