### PR TITLE
Fix: Remove references to slow server api1.aleph.im

### DIFF
--- a/docs/libraries/networks.md
+++ b/docs/libraries/networks.md
@@ -6,7 +6,7 @@ Aleph.im provides robust decentralized infrastructure to empower developers and 
 
 | Network | CCN APIs | Explorer |
 |---------|----------|----------|
-| **Mainnet** | • [https://api1.aleph.im](https://api1.aleph.im/)<br>• [https://api2.aleph.im](https://api2.aleph.im)<br>• [https://api3.aleph.im](https://api3.aleph.im/) | • [https://explorer.aleph.im](https://explorer.aleph.im/) |
+| **Mainnet** | • [https://api2.aleph.im](https://api2.aleph.im)<br>• [https://api3.aleph.im](https://api3.aleph.im/) | • [https://explorer.aleph.im](https://explorer.aleph.im/) |
 | **Testnet** | • [https://api.twentysix.testnet.network](https://api.twentysix.testnet.network/) | • [https://explorer.testnet.aleph.im](https://explorer.testnet.aleph.im/) |
 
 ## Choose A Network


### PR DESCRIPTION
Server api1.aleph.im is very slow and outdated
(Core i7 from 2018, up to 40 seconds to respond
to `/metrics` in the monitoring).

We suspect that this causes issues in the
monitoring and performance of the network.

This branch removes all references to api1 and
replaces them with api3 where relevant.
